### PR TITLE
Update NixOS Wiki link

### DIFF
--- a/nix/home/firefox.nix
+++ b/nix/home/firefox.nix
@@ -110,10 +110,10 @@
           "NixOS Wiki" = {
             urls = [
               {
-                template = "https://nixos.wiki/index.php?search={searchTerms}";
+                template = "https://wiki.nixos.org/index.php?search={searchTerms}";
               }
             ];
-            iconUpdateURL = "https://nixos.wiki/favicon.png";
+            iconUpdateURL = "https://wiki.nixos.org/favicon.png";
             updateInterval = 24 * 60 * 60 * 1000; # every day
             definedAliases = ["@nix"];
           };

--- a/windows/README.md
+++ b/windows/README.md
@@ -8,7 +8,7 @@
     - Simply copying the ISO to drive resulted in Windows installer that "could not locate drivers".
     - Try above tool before attempting to customize the ISO.
 - BIOS and booting
-    - See [Dual Booting NixOS and Windows](https://nixos.wiki/wiki/Dual_Booting_NixOS_and_Windows)
+    - See [Dual Booting NixOS and Windows](https://wiki.nixos.org/wiki/Dual_Booting_NixOS_and_Windows)
     - Ideally GRUB is configured to boot Linux + Windows with Secure Boot enabled[1], but this turns out to be non-trivial/impossible.
     - Use case for Secure Boot was Riot's Vanguard (anti-cheat) software, needed to play their games.
 


### PR DESCRIPTION
Hello there 👋!

The NixOS wiki is in the process of migrating from https://nixos.wiki to https://wiki.nixos.org.
You can find more information about it [here](https://github.com/NixOS/foundation/issues/113).

You seem to be using the old link in your repository, which is why we send you this PR.
If you feel like this is not correct or have any questions, feel free to [get in touch with us](https://github.com/NixOS/nixos-wiki-infra/issues/105).


Have a great day,

-- The NixOS Wiki-Team ❄️