### PR TITLE
Add microvm NixOS configuration with hermes-agent

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,8 @@
     flake-root.url = "github:srid/flake-root";
     globset.url = "github:pdtpartners/globset";
     hermes-agent.url = "github:NousResearch/hermes-agent";
+    microvm.url = "github:microvm-nix/microvm.nix";
+    microvm.inputs.nixpkgs.follows = "nixpkgs";
     nix-colors.url = "github:misterio77/nix-colors";
     nixvim.url = "github:nix-community/nixvim";
     nixvim.inputs.nixpkgs.follows = "nixpkgs";
@@ -137,6 +139,10 @@
           framework = mkNixosSystem {
             system = "x86_64-linux";
             modules = [./nixos/framework/configuration.nix];
+          };
+          microvm = mkNixosSystem {
+            system = "x86_64-linux";
+            modules = [./nixos/microvm/configuration.nix];
           };
           nijusan = mkNixosSystem {
             system = "x86_64-linux";

--- a/home-manager/microvm.nix
+++ b/home-manager/microvm.nix
@@ -1,0 +1,27 @@
+{
+  self,
+  config,
+  pkgs,
+  lib,
+  ...
+}: {
+  imports = [
+    self.homeModules.common
+    ../nix/home/dev
+    ../nix/home/nixvim
+    ../nix/home/atuin.nix
+    ../nix/home/tmux.nix
+    ../nix/home/ssh.nix
+    ../nix/home/pretty.nix
+    ../nix/home/home-manager.nix
+  ];
+
+  programs.atuin.enable = true;
+  programs.nixvim.enable = true;
+  programs.nixvim.defaultEditor = true;
+  programs.ssh.enable = true;
+
+  home.username = "logan";
+  home.homeDirectory = "/home/logan";
+  home.stateVersion = "23.05";
+}

--- a/nixos/microvm/configuration.nix
+++ b/nixos/microvm/configuration.nix
@@ -1,0 +1,113 @@
+{
+  self,
+  inputs,
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+with lib; {
+  imports = [
+    inputs.microvm.nixosModules.microvm
+    inputs.sops-nix.nixosModules.sops
+    inputs.nixvim.nixosModules.nixvim
+    ../../nix/modules/programs/nixvim
+    self.nixosModules.common
+    self.nixosModules.docker
+    self.nixosModules.home-manager
+    self.nixosModules.networking
+    self.nixosModules.syncthing
+    self.nixosModules.tailscale
+    ./hermes-agent.nix
+  ];
+
+  home-manager.users.logan = import ../../home-manager/microvm.nix;
+
+  networking.hostName = "microvm";
+
+  # Headless VM: drive the network with systemd-networkd instead of
+  # NetworkManager (which expects a desktop/interactive host).
+  networking.networkmanager.enable = mkForce false;
+  networking.useNetworkd = true;
+  networking.useDHCP = false;
+  systemd.network.enable = true;
+  systemd.network.networks."20-lan" = {
+    matchConfig.Type = "ether";
+    networkConfig = {
+      DHCP = "yes";
+      IPv6AcceptRA = true;
+    };
+  };
+
+  # sops-nix decrypts at activation using this host's SSH key. The host's age
+  # key (derive with `ssh-to-age < /etc/ssh/ssh_host_ed25519_key.pub`) must be
+  # added to .sops.yaml and the secrets re-encrypted before hermes can start.
+  sops.age.sshKeyPaths = ["/etc/ssh/ssh_host_ed25519_key"];
+
+  services.openssh.enable = true;
+  services.syncthing.enable = true;
+  services.tailscale.enable = true;
+
+  virtualisation.docker.enable = true;
+
+  security.polkit.enable = true;
+
+  programs.git.enable = true;
+  programs.git.package = pkgs.gitFull;
+  programs.htop.enable = true;
+  programs.zsh.enable = true;
+  programs.gnupg.agent.enable = true;
+  programs.gnupg.agent.enableSSHSupport = true;
+  programs.nixvim.enable = true;
+  programs.nixvim.defaultEditor = true;
+
+  environment.systemPackages = with pkgs; [
+    pciutils
+    usbutils
+  ];
+
+  # ---- microvm.nix guest definition -------------------------------------
+  # Build with: nix build .#nixosConfigurations.microvm.config.microvm.declaredRunner
+  # or run directly: nix run .#nixosConfigurations.microvm.config.microvm.declaredRunner
+  microvm = {
+    hypervisor = "qemu";
+    vcpu = 4;
+    mem = 4096;
+
+    interfaces = [
+      {
+        type = "tap";
+        id = "vm-microvm";
+        mac = "02:00:00:00:00:01";
+      }
+    ];
+
+    # Share the host's read-only Nix store over virtiofs and keep guest store
+    # writes on a persistent overlay volume, rather than baking a full store
+    # image into the VM.
+    shares = [
+      {
+        tag = "ro-store";
+        source = "/nix/store";
+        mountPoint = "/nix/.ro-store";
+        proto = "virtiofs";
+      }
+    ];
+    writableStoreOverlay = "/nix/.rw-store";
+
+    volumes = [
+      {
+        image = "microvm-nix-overlay.img";
+        mountPoint = "/nix/.rw-store";
+        size = 8192; # 8 GiB
+      }
+      {
+        image = "microvm-var.img";
+        mountPoint = "/var";
+        size = 16384; # 16 GiB — hermes + syncthing + docker state
+      }
+    ];
+  };
+
+  system.stateVersion = "23.05";
+}

--- a/nixos/microvm/hermes-agent.nix
+++ b/nixos/microvm/hermes-agent.nix
@@ -1,0 +1,78 @@
+{
+  config,
+  inputs,
+  pkgs,
+  lib,
+  ...
+}: {
+  imports = [
+    inputs.hermes-agent.nixosModules.default
+  ];
+
+  sops.secrets = {
+    hermesEnvironmentFile = {
+      sopsFile = ../../secrets/hermes.env;
+      format = "dotenv";
+    };
+  };
+
+  services.hermes-agent = {
+    enable = true;
+    addToSystemPackages = true;
+    environmentFiles = [config.sops.secrets.hermesEnvironmentFile.path];
+    settings = {
+      model = {
+        provider = "nous";
+        default = "deepseek/deepseek-v4-pro";
+      };
+      toolsets = ["all"];
+      terminal = {
+        backend = "local";
+        timeout = 180;
+      };
+      memory = {
+        memory_enabled = true;
+        user_profile_enabled = true;
+      };
+    };
+    extraDependencyGroups = [
+      "anthropic"
+      "honcho"
+      "hindsight"
+      "messaging"
+    ];
+    extraPackages = with pkgs; [
+      age
+      as-tree
+      bat
+      coreutils-full
+      curl
+      direnv
+      file
+      fzf
+      gawk
+      gh
+      git
+      gnugrep
+      gnupg
+      gnused
+      gnutar
+      jq
+      moreutils
+      repgrep
+      ripgrep
+      sd
+      sops
+      tree
+      unzip
+      wget
+      zip
+    ];
+    mcpServers = {
+      nixos = {
+        command = "${pkgs.mcp-nixos}/bin/mcp-nixos";
+        args = [];
+      };
+    };
+  };
+}


### PR DESCRIPTION
## Summary
Adds a new NixOS microvm configuration for running a headless QEMU virtual machine with hermes-agent AI assistant capabilities, along with supporting services and development tools.

## Key Changes
- **New microvm NixOS configuration** (`nixos/microvm/configuration.nix`):
  - Configures a 4-vCPU, 4GB RAM QEMU guest with persistent storage volumes
  - Uses systemd-networkd for headless networking with DHCP
  - Shares host's read-only Nix store via virtiofs with writable overlay
  - Integrates sops-nix for encrypted secrets management
  - Enables Docker, Syncthing, Tailscale, and SSH services
  - Includes development tools (git, zsh, nixvim, gnupg)

- **Hermes-agent service module** (`nixos/microvm/hermes-agent.nix`):
  - Configures hermes-agent with Nous provider and deepseek-v4-pro model
  - Enables memory and user profile features
  - Includes comprehensive toolset with MCP server for NixOS
  - Provides extensive CLI utilities (ripgrep, jq, fzf, etc.) for agent operations
  - Loads environment configuration from encrypted secrets

- **Home-manager configuration** (`home-manager/microvm.nix`):
  - Sets up user environment for the `logan` user
  - Enables development tools (atuin, nixvim, tmux, ssh)
  - Imports common home-manager modules

- **Flake updates**:
  - Adds microvm.nix input with nixpkgs pinning
  - Registers microvm NixOS configuration in flake outputs

## Notable Implementation Details
- VM storage is split into two volumes: 8GB for Nix store overlay and 16GB for `/var` (hermes, syncthing, docker state)
- SSH host key-based age encryption for sops-nix secrets decryption
- Tap interface networking with fixed MAC address for consistent VM identification

https://claude.ai/code/session_01UMsiabv3W85P4z9KBjgxPe